### PR TITLE
Added infer method that takes unsorted arrays of input indices and times

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Compilation requires c++17.
 
 Here is a C++ example of a (very) small fully-connected SNN in EvSpikeSim:
 ```cpp
-#include <evspikesim/Layers/FCLayer.h>
 #include <evspikesim/SpikingNetwork.h>
+#include <evspikesim/Layers/FCLayer.h>
 
 namespace sim = EvSpikeSim;
 
@@ -170,14 +170,9 @@ int main() {
     // Create input spikes
     std::vector<unsigned int> input_indices = {0, 1, 1};
     std::vector<float> input_times = {1.0, 1.5, 1.2};
-    auto input_spikes = sim::SpikeArray(input_indices, input_times);
-    input_spikes.sort();
 
     // Inference
-    auto output_spikes = network.infer(input_spikes);
-
-    std::cout << "Input spikes:" << std::endl;
-    std::cout << input_spikes << std::endl;
+    auto output_spikes = network.infer(input_indices, input_times);
 
     std::cout << "Output spikes:" << std::endl;
     std::cout << output_spikes << std::endl;
@@ -199,48 +194,34 @@ import evspikesim as sim
 import numpy as np
 
 
-def main():
+if __name__ == "__main__":
     # Create network
     network = sim.SpikingNetwork()
 
-    # Layer parameters
-    n_inputs = 2
-    n_neurons = 3
-    tau_s = 0.020
-    threshold = tau_s * 0.2
-
     # Add fully-connected layer to the network
-    desc = sim.layers.FCLayerDescriptor(n_inputs, n_neurons, tau_s, threshold)
+    desc = sim.layers.FCLayerDescriptor(n_inputs=2, n_neurons=3, tau_s=0.020, threshold=0.020 * 0.2)
     layer = network.add_layer(desc)
 
     # Set weights
     layer.weights = np.array([[1.0, 0.3],
                               [-0.1, 0.8],
-                              [0.5, 0.4]], dtype=np.float32) # Weights need to be of type float32
+                              [0.5, 0.4]], dtype=np.float32)
 
     # Mutate weight
     layer.weights[0, 1] -= 0.1
 
     # Create input spikes
-    input_indices = np.array([0, 1, 1], dtype=np.uint32) # Spike indices need to be of type uint32 or int32
-    input_times = np.array([1.0, 1.5, 1.2], dtype=np.float32) # Spike times need to be of type float32
-    input_spikes = sim.SpikeArray(input_indices, input_times)
-    input_spikes.sort() # Input spikes need to be sorted in time prior to inference
+    input_indices = np.array([0, 1, 1], dtype=np.int32)
+    input_times = np.array([1.0, 1.5, 1.2], dtype=np.float32)
 
     # Inference
-    output_spikes = network.infer(input_spikes)
-
-    print("Input spikes:")
-    print(input_spikes)
+    output_spikes = network.infer(input_indices, input_times)
 
     print("Output spikes:")
     print(output_spikes)
 
     print("Output spike counts:")
     print(layer.n_spikes)
-
-if __name__ == "__main__":
-    main()
 ```
 This code can run with either the CPU or GPU versions of EvSpikeSim.
 

--- a/core/common/src/SpikeArray.cpp
+++ b/core/common/src/SpikeArray.cpp
@@ -7,6 +7,8 @@
 
 using namespace EvSpikeSim;
 
+SpikeArray::SpikeArray() : spikes(), sorted(true) {}
+
 SpikeArray::SpikeArray(const std::vector<unsigned int> &indices, const std::vector<float> &times) :
         SpikeArray(indices.begin(), indices.end(), times.begin()) {}
 
@@ -14,6 +16,7 @@ void SpikeArray::add(unsigned int index, float time) {
     if (is_max_capacity())
         extend_capacity();
     spikes.emplace_back(index, time);
+    sorted = false;
 }
 
 void SpikeArray::add(const std::vector<unsigned int> &indices, const std::vector<float> &times) {
@@ -21,11 +24,38 @@ void SpikeArray::add(const std::vector<unsigned int> &indices, const std::vector
 }
 
 void SpikeArray::sort() {
+    if (is_sorted())
+        return;
     std::sort(spikes.begin(), spikes.end());
+    sorted = true;
 }
 
 void SpikeArray::clear() {
     spikes.clear();
+}
+
+SpikeArray::const_iterator SpikeArray::begin() const {
+    return spikes.begin();
+};
+
+SpikeArray::const_iterator SpikeArray::end() const {
+    return spikes.end();
+};
+
+std::size_t SpikeArray::n_spikes() const {
+    return spikes.size();
+}
+
+bool SpikeArray::is_sorted() const {
+    return sorted;
+}
+
+bool SpikeArray::empty() const {
+    return n_spikes() == 0;
+}
+
+const Spike *SpikeArray::c_ptr() const {
+    return spikes.data();
 }
 
 bool SpikeArray::operator==(const SpikeArray &rhs) const {
@@ -40,4 +70,12 @@ std::ostream &EvSpikeSim::operator<<(std::ostream &os, const SpikeArray &array) 
     for (const auto &spike : array)
         os << spike << std::endl;
     return os;
+}
+
+bool SpikeArray::is_max_capacity() const {
+    return spikes.size() == spikes.capacity();
+}
+
+void SpikeArray::extend_capacity() {
+    spikes.reserve(spikes.capacity() + block_size);
 }

--- a/core/common/src/SpikingNetwork.cpp
+++ b/core/common/src/SpikingNetwork.cpp
@@ -7,11 +7,30 @@
 
 using namespace EvSpikeSim;
 
-const SpikeArray& SpikingNetwork::infer(const SpikeArray &pre_spikes) {
+const SpikeArray &SpikingNetwork::infer(const SpikeArray &pre_spikes) {
     auto *spikes = &pre_spikes;
 
+    if (!pre_spikes.is_sorted())
+        throw std::runtime_error("Input spikes must be sorted in time. Please call the .sort() method "
+                                 "before inference.");
     for (auto &layer : layers)
         spikes = &layer->infer(*spikes);
 
     return *spikes;
+}
+
+SpikingNetwork::iterator SpikingNetwork::begin() {
+    return layers.begin();
+}
+
+SpikingNetwork::iterator SpikingNetwork::end() {
+    return layers.end();
+}
+
+std::shared_ptr<Layer> SpikingNetwork::get_output_layer() {
+    return layers.back();
+}
+
+unsigned int SpikingNetwork::get_n_layers() const {
+    return layers.size();
 }

--- a/core/cpu/inc/evspikesim/SpikeArray.h
+++ b/core/cpu/inc/evspikesim/SpikeArray.h
@@ -15,24 +15,24 @@ namespace EvSpikeSim {
         using const_iterator = std::vector<Spike>::const_iterator;
 
     public:
-        SpikeArray() = default;
+        SpikeArray();
 
         SpikeArray(const std::vector<unsigned int> &indices, const std::vector<float> &times);
 
         template<class IndexIterator, class TimeIterator>
-        SpikeArray(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) {
+        SpikeArray(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) :
+                spikes(), sorted(true) {
             add(begin_indices, end_indices, begin_times);
         }
 
         void add(unsigned int index, float time);
+
         void add(const std::vector<unsigned int> &indices, const std::vector<float> &times);
 
         template<class IndexIterator, class TimeIterator>
         void add(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) {
             while (begin_indices != end_indices) {
-                if (is_max_capacity())
-                    extend_capacity();
-                spikes.emplace_back(*begin_indices, *begin_times);
+                add(*begin_indices, *begin_times);
                 begin_indices++;
                 begin_times++;
             }
@@ -42,15 +42,17 @@ namespace EvSpikeSim {
 
         void clear();
 
-        inline const_iterator begin() const { return spikes.begin(); };
+        const_iterator begin() const;
 
-        inline const_iterator end() const { return spikes.end(); };
+        const_iterator end() const;
 
-        inline std::size_t n_spikes() const { return spikes.size(); }
+        std::size_t n_spikes() const;
 
-        inline bool empty() const { return n_spikes() == 0; }
+        bool is_sorted() const;
 
-        inline const Spike *c_ptr() const { return spikes.data(); }
+        bool empty() const;
+
+        const Spike *c_ptr() const;
 
         bool operator==(const SpikeArray &rhs) const;
 
@@ -60,11 +62,12 @@ namespace EvSpikeSim {
         static constexpr size_t block_size = 1024;
 
         std::vector<Spike> spikes;
+        bool sorted;
 
     private:
-        inline bool is_max_capacity() const { return spikes.size() == spikes.capacity(); }
+        inline bool is_max_capacity() const;
 
-        inline void extend_capacity() { spikes.reserve(spikes.capacity() + block_size); }
+        inline void extend_capacity();
     };
 
     // IOStreams

--- a/core/cpu/inc/evspikesim/SpikingNetwork.h
+++ b/core/cpu/inc/evspikesim/SpikingNetwork.h
@@ -28,16 +28,25 @@ namespace EvSpikeSim {
 
         const SpikeArray &infer(const SpikeArray &pre_spikes);
 
+        template <class IndicesType, class TimesType>
+        const SpikeArray &infer(const IndicesType &indices, const TimesType &times) {
+            SpikeArray input_spikes(indices, times);
+
+            input_spikes.sort();
+            return infer(input_spikes);
+        }
+
         // Iterator
-        inline iterator begin() { return layers.begin(); };
-        inline iterator end() { return layers.end(); };
+        iterator begin();
+        iterator end();
 
         // Accessor
         template <typename T>
-        inline std::shared_ptr<Layer> operator[](T idx) { return layers[idx]; }
-        inline std::shared_ptr<Layer> get_output_layer() { return layers.back(); }
+        std::shared_ptr<Layer> operator[](T idx) { return layers[idx]; }
 
-        inline auto get_n_layers() const { return layers.size(); }
+        std::shared_ptr<Layer> get_output_layer();
+
+        unsigned int get_n_layers() const;
 
     private:
         std::shared_ptr<ThreadPool> thread_pool;

--- a/core/gpu/inc/evspikesim/SpikeArray.h
+++ b/core/gpu/inc/evspikesim/SpikeArray.h
@@ -10,60 +10,30 @@
 #include <evspikesim/Spike.h>
 #include <evspikesim/Misc/CudaManagedAllocator.h>
 
-/*
- * Notes on the Spike vector container for SpikeArray and the efficiency of spike sorting.
- *
- * We conduced experiments on sorting of std::vector<float>, std::vector<float, CudaManagedAllocator<float>>,
- * thrust::universal_vector<float> and thrust::device_vector<float>
- *
- * For 1000 elements and 1000 iterations:
- *
- * std::vector<float>, std::sort: 218ms
- * thrust::universal_vector<float>, std::sort: 5028ms
- * thrust::universal_vector<float>, thrust::sort: 5022ms
- * std::vector<float, cudaManagedAllocator<float>>, std::sort: 45ms (best)
- * std::vector<float, cudaManagedAllocator<float>>, thrust::sort: 111ms
- * thrust::device_vector<float>, thrust::sort: 117ms
- *
- * For 100 000 elements and 10 iterations:
- *
- * std::vector<float>, std::sort: 154ms
- * thrust::universal_vector<float>, std::sort: 4968ms
- * thrust::universal_vector<float>, thrust::sort: 4910ms
- * std::vector<float, cudaManagedAllocator<float>>, std::sort: 69ms
- * std::vector<float, cudaManagedAllocator<float>>, thrust::sort: 16ms
- * thrust::device_vector<float>, thrust::sort: 12ms (best)
- *
- * thrust::universal_vector (unified memory) are very slow as they seem to transfer data every time an element is
- * pushed on the cpu.
- * Thrust::sort is efficient only on large vectors (10x faster than CPU with 100 000 elements) but std::sort seems to
- * be faster on GPU
- */
-
 namespace EvSpikeSim {
     class SpikeArray {
     public:
         using const_iterator = std::vector<Spike, CudaManagedAllocator<Spike>>::const_iterator;
 
     public:
-        SpikeArray() = default;
+        SpikeArray();
 
         SpikeArray(const std::vector<unsigned int> &indices, const std::vector<float> &times);
 
         template<class IndexIterator, class TimeIterator>
-        SpikeArray(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) {
+        SpikeArray(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) :
+                spikes(), sorted(true) {
             add(begin_indices, end_indices, begin_times);
         }
 
         void add(unsigned int index, float time);
+
         void add(const std::vector<unsigned int> &indices, const std::vector<float> &times);
 
         template<class IndexIterator, class TimeIterator>
         void add(IndexIterator begin_indices, IndexIterator end_indices, TimeIterator begin_times) {
             while (begin_indices != end_indices) {
-                if (is_max_capacity())
-                    extend_capacity();
-                spikes.emplace_back(*begin_indices, *begin_times);
+                add(*begin_indices, *begin_times);
                 begin_indices++;
                 begin_times++;
             }
@@ -73,15 +43,17 @@ namespace EvSpikeSim {
 
         void clear();
 
-        inline const_iterator begin() const { return spikes.begin(); };
+        const_iterator begin() const;
 
-        inline const_iterator end() const { return spikes.end(); };
+        const_iterator end() const;
 
-        inline std::size_t n_spikes() const { return spikes.size(); }
+        std::size_t n_spikes() const;
 
-        inline bool empty() const { return n_spikes() == 0; }
+        bool is_sorted() const;
 
-        inline const Spike *c_ptr() const { return spikes.data(); }
+        bool empty() const;
+
+        const Spike *c_ptr() const;
 
         bool operator==(const SpikeArray &rhs) const;
 
@@ -91,11 +63,12 @@ namespace EvSpikeSim {
         static constexpr size_t block_size = 1024;
 
         std::vector<Spike, CudaManagedAllocator<Spike>> spikes;
+        bool sorted;
 
     private:
-        inline bool is_max_capacity() const { return spikes.size() == spikes.capacity(); }
+        inline bool is_max_capacity() const;
 
-        inline void extend_capacity() { spikes.reserve(spikes.capacity() + block_size); }
+        inline void extend_capacity();
     };
 
     // IOStreams

--- a/core/gpu/inc/evspikesim/SpikingNetwork.h
+++ b/core/gpu/inc/evspikesim/SpikingNetwork.h
@@ -27,16 +27,25 @@ namespace EvSpikeSim {
 
         const SpikeArray &infer(const SpikeArray &pre_spikes);
 
+        template <class IndicesType, class TimesType>
+        const SpikeArray &infer(const IndicesType &indices, const TimesType &times) {
+            SpikeArray input_spikes(indices, times);
+
+            input_spikes.sort();
+            return infer(input_spikes);
+        }
+
         // Iterator
-        inline iterator begin() { return layers.begin(); };
-        inline iterator end() { return layers.end(); };
+        iterator begin();
+        iterator end();
 
         // Accessor
         template <typename T>
-        inline std::shared_ptr<Layer> operator[](T idx) { return layers[idx]; }
-        inline std::shared_ptr<Layer> get_output_layer() { return layers.back(); }
+        std::shared_ptr<Layer> operator[](T idx) { return layers[idx]; }
 
-        inline auto get_n_layers() const { return layers.size(); }
+        std::shared_ptr<Layer> get_output_layer();
+
+        unsigned int get_n_layers() const;
 
     private:
         std::vector<std::shared_ptr<Layer>> layers;

--- a/core/tests/SpikeNetwork_test.cpp
+++ b/core/tests/SpikeNetwork_test.cpp
@@ -25,7 +25,7 @@ TEST(SpikingNetworkTest, AddLayer) {
     ASSERT_EQ(network.get_n_layers(), 3u);
 }
 
-TEST(SpikingNetworkTest, Inference) {
+TEST(SpikingNetworkTest, InferenceSpikeArray) {
     FCLayerDescriptor desc(2, 3, 0.020, 0.020 * 0.2);
     SpikingNetwork network = SpikingNetwork();
     auto layer = network.add_layer(desc);
@@ -56,6 +56,37 @@ TEST(SpikingNetworkTest, Inference) {
     input_spikes.sort();
 
     const auto &post_spikes = network.infer(input_spikes);
+
+    ASSERT_EQ(post_spikes, true_outputs);
+}
+
+TEST(SpikingNetworkTest, InferenceVectors) {
+    FCLayerDescriptor desc(2, 3, 0.020, 0.020 * 0.2);
+    SpikingNetwork network = SpikingNetwork();
+    auto layer = network.add_layer(desc);
+    std::vector<unsigned int> input_indices = {0, 1, 1};
+    std::vector<float> input_times = {1.0, 1.5, 1.2};
+
+    float weights[] = {1.0, 0.2,
+                       -0.1, 0.8,
+                       0.5, 0.4};
+
+    SpikeArray true_outputs = SpikeArray();
+    true_outputs.add(0, 1.0047829);
+    true_outputs.add(0, 1.0112512);
+    true_outputs.add(0, 1.0215546);
+    true_outputs.add(1, 1.2063813);
+    true_outputs.add(1, 1.2163547);
+    true_outputs.add(1, 1.506313);
+    true_outputs.add(1, 1.5162327);
+    true_outputs.add(2, 1.0129402);
+    true_outputs.add(2, 1.2233235);
+    true_outputs.add(2, 1.5267321);
+    true_outputs.sort();
+
+    std::copy(weights, weights + 6, layer->get_weights().c_ptr());
+
+    const auto &post_spikes = network.infer(input_indices, input_times);
 
     ASSERT_EQ(post_spikes, true_outputs);
 }

--- a/core/tests/SpikeNetwork_test.cpp
+++ b/core/tests/SpikeNetwork_test.cpp
@@ -60,6 +60,22 @@ TEST(SpikingNetworkTest, InferenceSpikeArray) {
     ASSERT_EQ(post_spikes, true_outputs);
 }
 
+TEST(SpikingNetworkTest, InferenceSpikeArrayUnsortedThrow) {
+    FCLayerDescriptor desc(2, 3, 0.020, 0.020 * 0.2);
+    SpikingNetwork network = SpikingNetwork();
+    auto layer = network.add_layer(desc);
+
+    SpikeArray input_spikes = SpikeArray();
+
+    input_spikes.add(0, 1.0);
+    input_spikes.add(1, 1.5);
+    input_spikes.add(1, 1.2);
+
+    EXPECT_THROW({
+        network.infer(input_spikes);
+    }, std::runtime_error);
+}
+
 TEST(SpikingNetworkTest, InferenceVectors) {
     FCLayerDescriptor desc(2, 3, 0.020, 0.020 * 0.2);
     SpikingNetwork network = SpikingNetwork();

--- a/demos/example.cpp
+++ b/demos/example.cpp
@@ -2,8 +2,8 @@
 // Created by Florian Bacho on 02/02/23.
 //
 
-#include <evspikesim/Layers/FCLayer.h>
 #include <evspikesim/SpikingNetwork.h>
+#include <evspikesim/Layers/FCLayer.h>
 
 namespace sim = EvSpikeSim;
 
@@ -33,14 +33,9 @@ int main() {
     // Create input spikes
     std::vector<unsigned int> input_indices = {0, 1, 1};
     std::vector<float> input_times = {1.0, 1.5, 1.2};
-    auto input_spikes = sim::SpikeArray(input_indices, input_times);
-    input_spikes.sort();
 
     // Inference
-    auto output_spikes = network.infer(input_spikes);
-
-    std::cout << "Input spikes:" << std::endl;
-    std::cout << input_spikes << std::endl;
+    auto output_spikes = network.infer(input_indices, input_times);
 
     std::cout << "Output spikes:" << std::endl;
     std::cout << output_spikes << std::endl;

--- a/demos/example.py
+++ b/demos/example.py
@@ -2,18 +2,12 @@ import evspikesim as sim
 import numpy as np
 
 
-def main():
+if __name__ == "__main__":
     # Create network
     network = sim.SpikingNetwork()
 
-    # Layer parameters
-    n_inputs = 2
-    n_neurons = 3
-    tau_s = 0.020
-    threshold = tau_s * 0.2
-
     # Add fully-connected layer to the network
-    desc = sim.layers.FCLayerDescriptor(n_inputs, n_neurons, tau_s, threshold)
+    desc = sim.layers.FCLayerDescriptor(n_inputs=2, n_neurons=3, tau_s=0.020, threshold=0.020 * 0.2)
     layer = network.add_layer(desc)
 
     # Set weights
@@ -27,20 +21,12 @@ def main():
     # Create input spikes
     input_indices = np.array([0, 1, 1], dtype=np.int32)
     input_times = np.array([1.0, 1.5, 1.2], dtype=np.float32)
-    input_spikes = sim.SpikeArray(input_indices, input_times)
-    input_spikes.sort()
 
     # Inference
-    output_spikes = network.infer(input_spikes)
-
-    print("Input spikes:")
-    print(input_spikes)
+    output_spikes = network.infer(input_indices, input_times)
 
     print("Output spikes:")
     print(output_spikes)
 
     print("Output spike counts:")
     print(layer.n_spikes)
-
-if __name__ == "__main__":
-    main()

--- a/python_api/src/EvSpikeSimPackage.cpp
+++ b/python_api/src/EvSpikeSimPackage.cpp
@@ -83,11 +83,16 @@ static void create_main_module(py::module &m) {
     py::class_<SpikingNetwork>(m, "SpikingNetwork")
             .def(py::init<>())
             .def("add_layer", static_cast<std::shared_ptr<FCLayer> (SpikingNetwork::*)(const FCLayerDescriptor &)>
-                 (&SpikingNetwork::add_layer), py::arg("descriptor"))
-            .def("infer", &SpikingNetwork::infer, py::arg("inputs"))
+            (&SpikingNetwork::add_layer), py::arg("descriptor"))
+            .def("infer", static_cast<const SpikeArray &(SpikingNetwork::*)(const SpikeArray &)>
+                 (&SpikingNetwork::infer), py::arg("inputs"))
+            .def("infer", static_cast<const SpikeArray &(SpikingNetwork::*)(const std::vector<unsigned int> &,
+                                                                            const std::vector<float> &)>
+                 (&SpikingNetwork::infer),
+                 py::arg("indices"), py::arg("times"))
             .def("__len__", &SpikingNetwork::get_n_layers)
             .def("__iter__", &get_obj_iterator<SpikingNetwork>, py::keep_alive<0, 1>())
-            .def("__getitem__", &SpikingNetwork::operator[]<unsigned int>)
+            .def("__getitem__", &SpikingNetwork::operator[] < unsigned int > )
             .def_property_readonly("output_layer", &SpikingNetwork::get_output_layer);
 }
 

--- a/python_api/tests/SpikingNetwork_test.py
+++ b/python_api/tests/SpikingNetwork_test.py
@@ -96,6 +96,21 @@ class TestSpikingNetwork(unittest.TestCase):
         output_spikes = net.infer(inputs)
         self.assertEqual(output_spikes, targets)
 
+    def test_infer_spike_array_unsorted_exception(self):
+        weights = np.array([[1.0, 0.2],
+                            [-0.1, 0.8],
+                            [0.5, 0.4]], dtype=np.float32)
+
+        indices = np.array([0, 1, 1], dtype=np.uint32)
+        times = np.array([1.0, 1.5, 1.2], dtype=np.float32)
+        inputs = sim.SpikeArray(indices, times)
+
+        net = sim.SpikingNetwork()
+        layer = net.add_layer(FCLayerDescriptor(2, 3, 0.020, 0.020 * 0.2))
+        layer.weights = weights
+
+        self.assertRaises(RuntimeError, net.infer, inputs)
+
 
     def test_infer_no_spike_array(self):
         weights = np.array([[1.0, 0.2],

--- a/python_api/tests/SpikingNetwork_test.py
+++ b/python_api/tests/SpikingNetwork_test.py
@@ -73,7 +73,7 @@ class TestSpikingNetwork(unittest.TestCase):
             self.assertAlmostEqual(layer.descriptor.tau, 2 * tau_s)
             self.assertAlmostEqual(layer.descriptor.threshold, threshold)
 
-    def test_infer(self):
+    def test_infer_spike_array(self):
         weights = np.array([[1.0, 0.2],
                             [-0.1, 0.8],
                             [0.5, 0.4]], dtype=np.float32)
@@ -96,6 +96,28 @@ class TestSpikingNetwork(unittest.TestCase):
         output_spikes = net.infer(inputs)
         self.assertEqual(output_spikes, targets)
 
+
+    def test_infer_no_spike_array(self):
+        weights = np.array([[1.0, 0.2],
+                            [-0.1, 0.8],
+                            [0.5, 0.4]], dtype=np.float32)
+
+        input_indices = np.array([0, 1, 1], dtype=np.uint32)
+        input_times = np.array([1.0, 1.5, 1.2], dtype=np.float32)
+
+        targets_indices = np.array([0, 0, 0, 1, 1, 1, 1, 2, 2, 2], dtype=np.uint32)
+        targets_times = np.array([1.0047829, 1.0112512, 1.0215546, 1.2063813, 1.2163547, 1.506313, 1.5162327,
+                                  1.0129402, 1.2233235, 1.5267321], dtype=np.float32)
+        targets = sim.SpikeArray(targets_indices, targets_times)
+        targets.sort()
+
+        net = sim.SpikingNetwork()
+        layer = net.add_layer(FCLayerDescriptor(2, 3, 0.020, 0.020 * 0.2))
+        layer.weights = weights
+
+        output_spikes = net.infer(indices=input_indices, times=input_times)
+        self.assertEqual(output_spikes, targets)
+
     def test_infer_reset(self):
         weights = np.array([[1.0, 0.2],
                             [-0.1, 0.8],
@@ -116,6 +138,6 @@ class TestSpikingNetwork(unittest.TestCase):
         layer = net.add_layer(FCLayerDescriptor(2, 3, 0.020, 0.020 * 0.2))
         layer.weights = weights
 
-        output_spikes = net.infer(inputs) # Run a first time
+        net.infer(inputs) # Run a first time
         output_spikes = net.infer(inputs)
         self.assertEqual(output_spikes, targets)


### PR DESCRIPTION
Arrays of spike indices and times can be directly given as arguments to infer instead of creating a SpikeArray object and explicitly sorting it.